### PR TITLE
Add granular IAM permissions for VPC to support creation of vpc and vpc block volumes

### DIFF
--- a/randagroups/agroups/main.tf
+++ b/randagroups/agroups/main.tf
@@ -115,6 +115,26 @@ resource "ibm_iam_access_group_policy" "admins_is_volume_policy" {
   }
 }
 
+resource "ibm_iam_access_group_policy" "admins_is_floating_ip_policy" {
+  access_group_id = ibm_iam_access_group.admins_access_group.id
+  roles           = ["Editor"]
+  resources {
+    service = "is"
+    resource_type = "floating_ip"
+    resource_group_id = var.default_resource_group_id
+  }
+}
+
+resource "ibm_iam_access_group_policy" "admins_is_volume_policy" {
+  access_group_id = ibm_iam_access_group.admins_access_group.id
+  roles           = ["Editor"]
+  resources {
+    service = "is"
+    resource_type = "volume"
+    resource_group_id = var.default_resource_group_id
+  }
+}
+
 /*
  * create USER access group
  */

--- a/randagroups/agroups/main.tf
+++ b/randagroups/agroups/main.tf
@@ -65,6 +65,16 @@ resource "ibm_iam_access_group_policy" "admins_support_policy" {
   }
 }
 
+resource "ibm_iam_access_group_policy" "admins_is_vpc_policy" {
+  access_group_id = ibm_iam_access_group.admins_access_group.id
+  roles           = ["Editor"]
+  resources {
+    service = "is"
+    resource_type = "vpc"
+    resource_group_id = var.resource_group_id
+  }
+}
+
 /*
  * create USER access group
  */

--- a/randagroups/agroups/main.tf
+++ b/randagroups/agroups/main.tf
@@ -115,7 +115,7 @@ resource "ibm_iam_access_group_policy" "admins_is_volume_policy" {
   }
 }
 
-resource "ibm_iam_access_group_policy" "admins_is_floating_ip_policy" {
+resource "ibm_iam_access_group_policy" "admins_is_floating_ip_default_rg_policy" {
   access_group_id = ibm_iam_access_group.admins_access_group.id
   roles           = ["Editor"]
   resources {
@@ -125,7 +125,7 @@ resource "ibm_iam_access_group_policy" "admins_is_floating_ip_policy" {
   }
 }
 
-resource "ibm_iam_access_group_policy" "admins_is_volume_policy" {
+resource "ibm_iam_access_group_policy" "admins_is_volume_default_rg_policy" {
   access_group_id = ibm_iam_access_group.admins_access_group.id
   roles           = ["Editor"]
   resources {

--- a/randagroups/agroups/main.tf
+++ b/randagroups/agroups/main.tf
@@ -75,6 +75,46 @@ resource "ibm_iam_access_group_policy" "admins_is_vpc_policy" {
   }
 }
 
+resource "ibm_iam_access_group_policy" "admins_is_subnet_policy" {
+  access_group_id = ibm_iam_access_group.admins_access_group.id
+  roles           = ["Editor"]
+  resources {
+    service = "is"
+    resource_type = "subnet"
+    resource_group_id = var.resource_group_id
+  }
+}
+
+resource "ibm_iam_access_group_policy" "admins_is_public_gateway_policy" {
+  access_group_id = ibm_iam_access_group.admins_access_group.id
+  roles           = ["Editor"]
+  resources {
+    service = "is"
+    resource_type = "public_gateway"
+    resource_group_id = var.resource_group_id
+  }
+}
+
+resource "ibm_iam_access_group_policy" "admins_is_floating_ip_policy" {
+  access_group_id = ibm_iam_access_group.admins_access_group.id
+  roles           = ["Editor"]
+  resources {
+    service = "is"
+    resource_type = "floating_ip"
+    resource_group_id = var.resource_group_id
+  }
+}
+
+resource "ibm_iam_access_group_policy" "admins_is_volume_policy" {
+  access_group_id = ibm_iam_access_group.admins_access_group.id
+  roles           = ["Editor"]
+  resources {
+    service = "is"
+    resource_type = "volume"
+    resource_group_id = var.resource_group_id
+  }
+}
+
 /*
  * create USER access group
  */

--- a/randagroups/agroups/variables.tf
+++ b/randagroups/agroups/variables.tf
@@ -9,6 +9,12 @@ variable "resource_group_id" {
   description = "ID of the environment's resource group."
 }
 
+variable "default_resource_group_id" {
+  type        = string
+  description = "ID of the account's default resource group."
+}
+
+
 variable "admins_access_group_name" {
   type        = string
   description = "Name for the Admin access group for the environment."

--- a/randagroups/main.tf
+++ b/randagroups/main.tf
@@ -12,9 +12,10 @@ module "resource-groups" {
 module "access-groups" {
   source = "./agroups"
 
-  resource_group_name      = module.resource-groups.resource_group_name
-  resource_group_id        = module.resource-groups.resource_group_id
-  admins_access_group_name = var.admins_access_group_name
-  users_access_group_name  = var.users_access_group_name
+  resource_group_name       = module.resource-groups.resource_group_name
+  resource_group_id         = module.resource-groups.resource_group_id
+  default_resource_group_id = module.resource-groups.default_resource_group_id
+  admins_access_group_name  = var.admins_access_group_name
+  users_access_group_name   = var.users_access_group_name
 }
 

--- a/randagroups/rgroups/main.tf
+++ b/randagroups/rgroups/main.tf
@@ -6,6 +6,6 @@ resource "ibm_resource_group" "resourceGroup" {
   name = var.resource_group_name
 }
 
-resource "ibm_resource_group" "resourceGroupDefault" {
-  name = var.default_resource_group_name
+data "ibm_resource_group" "resourceGroupDefault" {
+  is_default = "true"
 }

--- a/randagroups/rgroups/main.tf
+++ b/randagroups/rgroups/main.tf
@@ -5,3 +5,7 @@
 resource "ibm_resource_group" "resourceGroup" {
   name = var.resource_group_name
 }
+
+resource "ibm_resource_group" "resourceGroupDefault" {
+  name = var.default_resource_group_name
+}

--- a/randagroups/rgroups/output.tf
+++ b/randagroups/rgroups/output.tf
@@ -7,3 +7,8 @@ output "resource_group_id" {
   description = "ID of the newly created resource group"
   value       = ibm_resource_group.resourceGroup.id
 }
+
+output "default_resource_group_id" {
+  description = "ID of the account default resource group"
+  value       = ibm_resource_group.resourceGroupDefault.id
+}

--- a/randagroups/rgroups/output.tf
+++ b/randagroups/rgroups/output.tf
@@ -10,5 +10,5 @@ output "resource_group_id" {
 
 output "default_resource_group_id" {
   description = "ID of the account default resource group"
-  value       = ibm_resource_group.resourceGroupDefault.id
+  value       = data.ibm_resource_group.resourceGroupDefault.id
 }

--- a/randagroups/rgroups/variables.tf
+++ b/randagroups/rgroups/variables.tf
@@ -3,3 +3,9 @@ variable "resource_group_name" {
   description = "Name for the resource group for the environment."
   default     = "test"
 }
+
+variable "default_resource_group_name" {
+  type        = string
+  description = "Name for the default resource group for the account."
+  default     = "Default"
+}

--- a/randagroups/rgroups/variables.tf
+++ b/randagroups/rgroups/variables.tf
@@ -3,9 +3,3 @@ variable "resource_group_name" {
   description = "Name for the resource group for the environment."
   default     = "test"
 }
-
-variable "default_resource_group_name" {
-  type        = string
-  description = "Name for the default resource group for the account."
-  default     = "Default"
-}


### PR DESCRIPTION
Extends current ADMINS access group. Adds Editor platform role in the target resource group for:

- vpc
- subnet
- security group
- floating ip
- public gateway
- block volume

Permissions previously tested but need final testing with updated automation for IAF